### PR TITLE
Forward compatibility with react/event-loop 1.0 and 0.5 while still supporting 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "react/event-loop": "~0.4.1"
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/functions.php
+++ b/src/functions.php
@@ -58,14 +58,3 @@ function addPeriodicTimer($interval, callable $callback) {
 function cancelTimer(TimerInterface $timer) {
     getLoop()->cancelTimer($timer);
 }
-
-/**
- * Check if a given timer is active.
- *
- * @param TimerInterface $timer The timer to check.
- *
- * @return boolean True if the timer is still enqueued for execution.
- */
-function isTimerActive(TimerInterface $timer) {
-    return getLoop()->isTimerActive($timer);
-}


### PR DESCRIPTION
Had to remove the `isTimerActive` function as we removed it from the event loop in 0.5